### PR TITLE
feat: introduces the `field` action and `reset` form

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "rollup -c rollup.config.js",
     "check": "tsc --noEmit",
     "coverage": "vitest run --coverage",
+    "dev": "rollup -c rollup.config.js --watch",
     "test": "vitest",
     "test:dev": "vitest watch",
     "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,23 @@
+import { FormInstance } from '.';
+
+export function field<T extends object>(
+  node: Node,
+  form: FormInstance<T>,
+): void {
+  if (!form) {
+    throw new Error('Missing "FormInstance".');
+  }
+
+  if ((node as any).tagName !== 'INPUT') {
+    throw new Error('Expected an `<input />` element.');
+  }
+
+  node.addEventListener('blur', form.handleBlur);
+  node.addEventListener('change', form.handleChange);
+  node.addEventListener('focus', form.handleFocus);
+  node.addEventListener('input', form.handleInput);
+
+  form.values.subscribe((values) => {
+    (node as any).value = values[(node as any).name];
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { clone } from './utils';
 import type { Readable, Writable } from 'svelte/store';
 import type { SchemaLike } from 'yup/lib/types';
 
+export { field } from './action';
+
 export type FormErrors<T> = Record<keyof T, string | undefined>;
 
 export type SetFieldError<T> = (field: keyof T, message?: string) => void;
@@ -100,6 +102,11 @@ export type FormInstance<T extends object> = {
    * `FormConfig`, then the `isValidating` store value will be `true` as well.
    */
   handleSubmit(event: Event): Promise<void>;
+
+  /**
+   * Resets form values back to the initial values
+   */
+  reset(): void;
 
   /**
    * Imperatively sets the initial values for the current form.
@@ -415,6 +422,10 @@ export const newForm: NewFormFn = <T extends object>(
     }
   };
 
+  const reset = (): void => {
+    values.set(get(__initialValues));
+  };
+
   const handleBlur = (event: Event): void => {
     const target = event.target as HTMLInputElement;
     const name = target.name as keyof T;
@@ -526,6 +537,7 @@ export const newForm: NewFormFn = <T extends object>(
     initialValues: derived(__initialValues, (initialValues) => initialValues),
     isSubmitting: derived(__isSubmitting, (isSubmitting) => isSubmitting),
     isValidating: derived(__isValidating, (isValidating) => isValidating),
+    reset,
     setFieldError,
     setFieldTouched,
     setFieldValue,


### PR DESCRIPTION
Introduces a `field` action, useful to reduce boilerplate when attaching
fields to a `FormInstance`.

This will let us write code similar to:

```svelte
<script>
  import { field, newForm } from 'manzana';

  const form = newForm({
    initialValues: {
      name: 'Esteban',
      password: 'admin',
    },
    onSubmit: () => {
      console.log('Hello');
    },
  });

  const values = form.values;
  const touched = form.touched;
</script>

<h1 class="text-3xl font-bold underline">Hello world!</h1>
{JSON.stringify($values)}
{JSON.stringify($touched)}
<input type="text" name="name" use:field={form} />
<input type="password" name="password" use:field={form} />
<button on:click={() => form.setFieldValue('name', 'Leo')}>Set Leo User</button>
<button on:click={() => form.reset()}>Reset</button>
```

If you refactor your code from the current implementation, you would get:

```diff
<script>
  import { newForm } from 'manzana';

  const form = newForm({
    // -- snip --
  });
</script>

<input
    type="text"
    name="username"
-   on:input={form.handleInput}
-   on:change={form.handleChange}
-   on:blur={form.handleBlur}
-   on:focus={form.handleFocus}
-   bind:value={$values.username}
-   error={$errors.username}
+   use:field={form}
/>
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
